### PR TITLE
Update main.dart

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,7 +59,7 @@ class SignUpSection extends StatelessWidget {
 signup(email, password) async {
   var url = "http://127.0.0.1:5000"; // iOS
   final http.Response response = await http.post(
-    url,
+    Uri.parse(url),
     headers: <String, String>{
       'Content-Type': 'application/json; charset=UTF-8',
     },


### PR DESCRIPTION
It's giving The argument type 'String' can't be assigned to the parameter type 'Uri'.dart(argument_type_not_assignable) error. So I fixed the problem with Uri.parse()